### PR TITLE
Remove unittest2 references

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ cache:
   directories:
     - eggs
 python:
-- "2.6"
 - "2.7"
 - "3.4"
+- "3.5"
 install:
 - python bootstrap.py
 - bin/buildout -N -t 3 versions:robotframework=$RF

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ as `plone.testing`_'s layered test suites:
 
 .. code:: python
 
-    import unittest2 as unittest
+    import unittest
 
     from plone.testing import layered
     from robotsuite import RobotTestSuite

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,7 @@ install_requires = [
 if PY3:
     install_requires.append('robotframework-python3>=2.8rc1')
 else:
-    install_requires.extend(['robotframework>=2.8rc1',
-                             'unittest2'])
+    install_requires.extend(['robotframework>=2.8rc1', ])
 
 setup(
     name='robotsuite',

--- a/src/robotsuite/__init__.py
+++ b/src/robotsuite/__init__.py
@@ -28,6 +28,7 @@ import shutil
 import string
 import types
 import unicodedata
+import unittest
 
 from robot import parsing as robot_parsing
 from robot import model as robot_model
@@ -37,10 +38,6 @@ from robot.conf import RobotSettings
 from robot.reporting import ResultWriter
 from robot.running import TestSuiteBuilder
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
 from lxml import etree
 
 try:


### PR DESCRIPTION
@datakurre is it ok to remove python 2.6 support (so in fact removing unittest2)?

That's the only and last package that depends on unittest2 that is used by Plone.