### PR TITLE
Drop robotframework-python3 requirement

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,8 +4,9 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Drop robotframework-python3 requirement,
+  robotframework itself is already python 3 compatible.
+  [gforcada]
 
 2.0.0 (2016-12-22)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ install_requires = [
     'setuptools',
     'lxml',
     'robotframework>=3.0',
-])
+]
 
 setup(
     name='robotsuite',

--- a/setup.py
+++ b/setup.py
@@ -6,13 +6,9 @@ PY3 = sys.version_info[0] == 3
 install_requires = [
     'six',
     'setuptools',
-    'lxml'
-]
-
-if PY3:
-    install_requires.append('robotframework-python3>=2.8rc1')
-else:
-    install_requires.extend(['robotframework>=2.8rc1', ])
+    'lxml',
+    'robotframework>=3.0',
+])
 
 setup(
     name='robotsuite',
@@ -25,7 +21,8 @@ setup(
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     keywords='',
     author='Asko Soukka',


### PR DESCRIPTION
robotframework itself is already python 3 compatible