### PR TITLE
Let tests be critical by default.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ Changelog
 2.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Let tests be critical by default.
+  Fixes `Plone issue 3537 <https://github.com/plone/Products.CMFPlone/issues/3537>`_.  [maurits]
 
 
 2.3.0 (2022-05-02)

--- a/src/robotsuite/__init__.py
+++ b/src/robotsuite/__init__.py
@@ -501,7 +501,6 @@ class RobotTestCase(unittest.TestCase):
         # Save the merged 'output.xml' and generate merged reports
         with open('robot_output.xml', 'wb') as handle:
             handle.write(data.encode('utf-8'))
-
         if HAS_CRITICALITY:
             robot_rebot('robot_output.xml', stdout=stdout, output='NONE',
                         log='robot_log.html', report='robot_report.html',
@@ -511,6 +510,8 @@ class RobotTestCase(unittest.TestCase):
                         log='robot_log.html', report='robot_report.html')
 
         # If the test is critical, raise AssertionError when it has failed
+        # By default, all tests are critical.
+        is_critical = True
         if HAS_CRITICALITY:
             criticality = robot_model.Criticality(
                 critical_tags=self._critical, non_critical_tags=self._noncritical)
@@ -520,8 +521,8 @@ class RobotTestCase(unittest.TestCase):
             ) or (
                 not criticality.non_critical_tags.match(self._tags)
             )
-            if is_critical:
-                assert last_status == 'PASS', last_message
+        if is_critical:
+            assert last_status == 'PASS', last_message
 
 
 def RobotTestSuite(*paths, **kw):


### PR DESCRIPTION
Fixes https://github.com/plone/Products.CMFPlone/issues/3537.

I have no idea how we missed this during the upgrade to robotframework 4 and 5. Those changes basically made robotsuite treat all tests as non critical.

Also, I am not sure why Jenkins does see jobs as failed, or at least unstable.