### PR TITLE
Drop pkg_resources usage

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,8 +4,8 @@ Changelog
 2.3.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Drop `pkg_resources` usage and replace it with `importlib.metadata` and `packaging.
+  [gforcada]
 
 2.3.2 (2023-09-09)
 ------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ install_requires =
     setuptools
     lxml
     robotframework>=2.8
+    packaging
 tests_require =
 package_dir =
     = src

--- a/src/robotsuite/__init__.py
+++ b/src/robotsuite/__init__.py
@@ -23,7 +23,6 @@ from six import StringIO
 import doctest
 import logging
 import os
-import pkg_resources
 import re
 import shutil
 import string
@@ -38,13 +37,15 @@ from robot.conf import RobotSettings
 from robot.reporting import ResultWriter
 from robot.running import TestSuiteBuilder
 
+from importlib.metadata import distribution
 from lxml import etree
+from packaging.version import parse as version_parse
 
-try:
-    pkg_resources.get_distribution('robotframework>=3.2a1')
+dist = distribution("robotframework>=3.2a1")
+
+if version_parse(dist.version) >= version_parse("3.2a1"):
     HAS_RF32_PARSER = True
-except pkg_resources.VersionConflict:
-    import robot.parsing as robot_parsing
+else:
     HAS_RF32_PARSER = False
 
 try:


### PR DESCRIPTION
See https://github.com/plone/Products.CMFPlone/issues/4126

❓ do we really want to keep testing with python 3.8 and still being compatible with python 2? 😅 