### PR TITLE
Fix merging XML report results

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ Changelog
 3.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix XML report merger.
+  [petschki]
 
 
 3.0.0 (2025-09-30)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,9 +1,14 @@
 [buildout]
 parts = test
 develop = .
+versions = versions
 
 [test]
 recipe = zc.recipe.testrunner==3.2
 eggs =
     robotsuite [test]
 defaults = ['--auto-color', '--auto-progress', '-s', 'robotsuite', '--test-path', '${buildout:directory}/src']
+
+[versions]
+zc.buildout = 4.1.12
+zc.recipe.egg = 3.0.0

--- a/src/robotsuite/__init__.py
+++ b/src/robotsuite/__init__.py
@@ -231,7 +231,6 @@ def merge(a, b):
             else:
                 for grandchild in child.iterchildren():
                     errors[0].append(grandchild)
-        a.attrib.update(b.attrib)
 
 
 class RobotListener(object):


### PR DESCRIPTION
There is a wrong line in the `merge()` method, which leads to false generated suite ids ...

merged XML in `2.3.2`:

<img width="1792" height="1014" alt="Bildschirmfoto 2025-11-18 um 13 20 19" src="https://github.com/user-attachments/assets/a5b5db62-53ce-4fcb-b7b5-0310db3a9bde" />

merged XML in `3.0.0`:

<img width="3614" height="2602" alt="Screenshot 2025-11-18 at 13-16-05 " src="https://github.com/user-attachments/assets/bd28cf8c-fd75-4faa-ba3a-64f65342fe4d" />
